### PR TITLE
fix md5 already being decoded

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
   "require": {
     "php": "^8.1",
     "league/flysystem": "^3.28",
-    "azure-oss/storage": "^1.1"
+    "azure-oss/storage": "^1.2"
   },
   "require-dev": {
     "laravel/pint": "^1.16",

--- a/src/AzureBlobStorageAdapter.php
+++ b/src/AzureBlobStorageAdapter.php
@@ -311,7 +311,7 @@ final class AzureBlobStorageAdapter implements FilesystemAdapter, ChecksumProvid
                 ->getBlobClient($this->prefixer->prefixPath($path))
                 ->getProperties();
 
-            return bin2hex(base64_decode($properties->contentMD5));
+            return $properties->contentMD5;
         } catch (\Throwable $e) {
             throw new UnableToProvideChecksum($e->getMessage(), $path, $e);
         }


### PR DESCRIPTION
Recent changes made it so that the md5 is already correctly decoded. Version 1.2 will need to be released first