### PR TITLE
change detectMimeTypeFromBuffer to detectMimeType

### DIFF
--- a/src/AzureBlobStorageAdapter.php
+++ b/src/AzureBlobStorageAdapter.php
@@ -104,7 +104,7 @@ final class AzureBlobStorageAdapter implements FilesystemAdapter, ChecksumProvid
         try {
             $options = $this->buildUploadOptionsFromConfig($config);
 
-            if ($options->httpHeaders->contentType === "" ) {
+            if ($options->httpHeaders->contentType === "") {
                 $options->httpHeaders->contentType = $this->mimeTypeDetector->detectMimeType($path, $contents) ?? "";
             }
 


### PR DESCRIPTION
detectMimeTypeFromBuffer is only used when contents is string, in previous version detectMimeType was used which does the is_string check on contents and then uses the detectMimeTypeFromBuffer if it is, else it fallsback to detectMimeTypeFrom path. this pr reintroduces this fallback.